### PR TITLE
fix: Update to use new CLI binary names

### DIFF
--- a/example_configs/aws.yml
+++ b/example_configs/aws.yml
@@ -1,5 +1,5 @@
 kind: source
 spec:
   name: 'aws'
-  version: 'v2.0.1'
+  version: "v3.4.2" # latest version of aws plugin
   destinations: ['postgresql']

--- a/example_configs/dest.yml
+++ b/example_configs/dest.yml
@@ -1,7 +1,7 @@
 kind: destination
 spec:
   name: 'postgresql'
-  version: 'v1.0.0'
+  version: "v1.3.3" # latest version of postgresql plugin
   write_mode: 'overwrite'
   spec:
     connection_string: 'postgresql://postgres:pass@localhost:5432/postgres?sslmode=disable'

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,8 @@ import semver from 'semver';
 import path from 'path';
 
 const binaries = {
-  darwin: 'cloudquery_darwin_x86_64',
-  linux: 'cloudquery_linux_x86_64',
+  darwin: 'cloudquery_darwin_amd64',
+  linux: 'cloudquery_linux_amd64',
 };
 
 const resolveDownloadUrl = async (version: string, binary: string) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ const binaries = {
 
 const resolveDownloadUrl = async (version: string, binary: string) => {
   if (version === 'latest') {
-    return `https://versions.cloudquery.io/latest/v1/${binary}`;
+    return `https://versions.cloudquery.io/latest/v2/${binary}`;
   }
   const tag = version.startsWith('v') ? `cli-${version}` : `cli-v${version}`;
   return `https://github.com/cloudquery/cloudquery/releases/download/${tag}/${binary}`;


### PR DESCRIPTION
Follow up to https://github.com/cloudquery/cloudquery/pull/3080