### PR TITLE
chore!: update minimal Node.js version to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'CloudQuery CLI version to install'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'cloud-snow'

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "semver": "7.6.3"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.3.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "incremental": true,
-    "target": "es2019",
-    "module": "ESNext",
-    "moduleResolution": "node",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowJs": true,
     "declaration": false,
     "declarationMap": false,


### PR DESCRIPTION
Node.js 16 actions are deprecated https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ and generate a warning 
![image](https://github.com/user-attachments/assets/b89a4bec-1e96-4b59-8d10-1dd3dc1d9601)
