### PR TITLE
chore: Replace broken actions-tagger with github-script for version tagging

### DIFF
--- a/.github/scripts/update-major-tag.js
+++ b/.github/scripts/update-major-tag.js
@@ -29,7 +29,7 @@ export default async function updateMajorTag({ github, context }) {
       });
       console.log(`Updated ${ref} to ${sha}`);
     } catch (error) {
-      if (error.status === 422) {
+      if (error?.status === 404 || error?.status === 422) {
         await github.rest.git.createRef({
           owner: context.repo.owner,
           repo: context.repo.repo,

--- a/.github/scripts/update-major-tag.js
+++ b/.github/scripts/update-major-tag.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /** @param {import('@actions/github-script').AsyncFunctionArguments} args */
-module.exports = async ({ github, context }) => {
+export default async function updateMajorTag({ github, context }) {
   const tag = context.payload.release?.tag_name;
   if (!tag) {
     throw new Error("No release tag found in event payload");
@@ -42,4 +42,4 @@ module.exports = async ({ github, context }) => {
       }
     }
   }
-};
+}

--- a/.github/scripts/update-major-tag.js
+++ b/.github/scripts/update-major-tag.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+/** @param {import('@actions/github-script').AsyncFunctionArguments} args */
+module.exports = async ({ github, context }) => {
+  const tag = context.payload.release?.tag_name;
+  if (!tag) {
+    throw new Error("No release tag found in event payload");
+  }
+
+  const match = tag.match(/^(v\d+)\.\d+\.\d+/);
+  if (!match) {
+    throw new Error(`Tag "${tag}" does not match semver pattern vX.Y.Z`);
+  }
+
+  const majorTag = match[1];
+  const sha = context.sha;
+
+  const tagsToUpdate = [majorTag, "latest"];
+
+  for (const tagName of tagsToUpdate) {
+    const ref = `tags/${tagName}`;
+    try {
+      await github.rest.git.updateRef({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref,
+        sha,
+        force: true,
+      });
+      console.log(`Updated ${ref} to ${sha}`);
+    } catch (error) {
+      if (error.status === 422) {
+        await github.rest.git.createRef({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          ref: `refs/${ref}`,
+          sha,
+        });
+        console.log(`Created ${ref} at ${sha}`);
+      } else {
+        throw error;
+      }
+    }
+  }
+};

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -11,7 +11,9 @@ jobs:
   actions-tagger:
     runs-on: ubuntu-latest
     steps:
-      - uses: Actions-R-Us/actions-tagger@148653c6179832f8392d083de6b46ad3dcc54de3
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          publish_latest_tag: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fn = require('./.github/scripts/update-major-tag.js');
+            await fn({ github, context });

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -11,9 +11,9 @@ jobs:
   actions-tagger:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const fn = require('./.github/scripts/update-major-tag.js');
-            await fn({ github, context });
+            const { default: updateMajorTag } = await import('${{ github.workspace }}/.github/scripts/update-major-tag.js');
+            await updateMajorTag({ github, context });


### PR DESCRIPTION
## Summary
Replace the broken `Actions-R-Us/actions-tagger` action (pinned commit no longer has `lib/index.js`) with `actions/github-script@v8` calling an external script that updates major version tags and the `latest` tag on release.